### PR TITLE
BREW-413: Add Required File for Linking

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,34 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "Q8V7YUM976.com.tastinggrounds.app",
+          "Q8V7YUM976.com.tastinggrounds.develop.app"
+        ],
+        "components": [
+          {
+            "/": "/coffee/*",
+            "comment": "Coffee links"
+          },
+          {
+            "/": "/roaster/*",
+            "comment": "Roaster links"
+          },
+          {
+            "/": "/farm/*",
+            "comment": "Farm links"
+          },
+          {
+            "/": "/producer/*",
+            "comment": "Producer links"
+          },
+          {
+            "/": "/brew/*",
+            "comment": "Brew links"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add the apple-app-site-association JSON which is required to be at the well known URL for apple to allow linking